### PR TITLE
Allow domain string to contain a dot

### DIFF
--- a/lib/Languages/Galach/SYNTAX.md
+++ b/lib/Languages/Galach/SYNTAX.md
@@ -161,7 +161,7 @@ one OR NOT (two AND three)
 Domain is an abstract category on which the term or group applies. It's defined by prefixing the
 term or group with a domain string, followed by a colon `:`. Domain string must start with at least
 one alphanumeric or underscore character and is followed by an arbitrary sequence of alphanumeric
-characters, hyphens `-` and underscores `_`.
+characters, hyphens `-`, underscores `_` and dots `.`.
 
 Note that the domain cannot be used on `Tag` and `User` terms. These two, in fact, define implicit
 domains of their own.
@@ -169,7 +169,7 @@ domains of their own.
 Regular expression for domain string:
 
 ```
-[a-zA-Z_][a-zA-Z0-9_\-]*
+[a-zA-Z_][a-zA-Z0-9_\-.]*
 ```
 
 Examples:

--- a/lib/Languages/Galach/TokenExtractor/Full.php
+++ b/lib/Languages/Galach/TokenExtractor/Full.php
@@ -31,11 +31,11 @@ final class Full extends TokenExtractor
         '/(?<lexeme>NOT)(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_NOT,
         '/(?<lexeme>(?:AND|&&))(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_AND,
         '/(?<lexeme>(?:OR|\|\|))(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_OR,
-        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-]*):)?(?<delimiter>\())/Au' => Tokenizer::TOKEN_GROUP_BEGIN,
+        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-.]*):)?(?<delimiter>\())/Au' => Tokenizer::TOKEN_GROUP_BEGIN,
         '/(?<lexeme>(?:(?<marker>(?<!\\\\)\#)(?<tag>[a-zA-Z0-9_][a-zA-Z0-9_\-.]*)))(?:[\s"()+!]|$)/Au' => Tokenizer::TOKEN_TERM,
         '/(?<lexeme>(?:(?<marker>(?<!\\\\)@)(?<user>[a-zA-Z0-9_][a-zA-Z0-9_\-.]*)))(?:[\s"()+!]|$)/Au' => Tokenizer::TOKEN_TERM,
-        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-]*):)?(?<quote>(?<!\\\\)["])(?<phrase>.*?)(?:(?<!\\\\)(?P=quote)))/Aus' => Tokenizer::TOKEN_TERM,
-        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-]*):)?(?<word>(?:\\\\\\\\|\\\\ |\\\\\(|\\\\\)|\\\\"|[^"()\s])+?))(?:(?<!\\\\)["]|\(|\)|$|\s)/Au' => Tokenizer::TOKEN_TERM,
+        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-.]*):)?(?<quote>(?<!\\\\)["])(?<phrase>.*?)(?:(?<!\\\\)(?P=quote)))/Aus' => Tokenizer::TOKEN_TERM,
+        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-.]*):)?(?<word>(?:\\\\\\\\|\\\\ |\\\\\(|\\\\\)|\\\\"|[^"()\s])+?))(?:(?<!\\\\)["]|\(|\)|$|\s)/Au' => Tokenizer::TOKEN_TERM,
     ];
 
     protected function getExpressionTypeMap()

--- a/lib/Languages/Galach/TokenExtractor/Text.php
+++ b/lib/Languages/Galach/TokenExtractor/Text.php
@@ -29,7 +29,7 @@ final class Text extends TokenExtractor
         '/(?<lexeme>NOT)(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_NOT,
         '/(?<lexeme>(?:AND|&&))(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_AND,
         '/(?<lexeme>(?:OR|\|\|))(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_OR,
-        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-]*):)?(?<delimiter>\())/Au' => Tokenizer::TOKEN_GROUP_BEGIN,
+        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-.]*):)?(?<delimiter>\())/Au' => Tokenizer::TOKEN_GROUP_BEGIN,
         '/(?<lexeme>(?<quote>(?<!\\\\)["])(?<phrase>.*?)(?:(?<!\\\\)(?P=quote)))/Aus' => Tokenizer::TOKEN_TERM,
         '/(?<lexeme>(?<word>(?:\\\\\\\\|\\\\ |\\\\\(|\\\\\)|\\\\"|[^"()\s])+?))(?:(?<!\\\\)["]|\(|\)|$|\s)/Au' => Tokenizer::TOKEN_TERM,
     ];

--- a/tests/Galach/Tokenizer/FullTokenizerTest.php
+++ b/tests/Galach/Tokenizer/FullTokenizerTest.php
@@ -435,9 +435,21 @@ class FullTokenizerTest extends TestCase
                 ],
             ],
             [
+                'some.domain:',
+                [
+                    new WordToken('some.domain:', 0, '', 'some.domain:'),
+                ],
+            ],
+            [
                 'domain:domain:',
                 [
                     new WordToken('domain:domain:', 0, 'domain', 'domain:'),
+                ],
+            ],
+            [
+                'some.domain:some.domain:',
+                [
+                    new WordToken('some.domain:some.domain:', 0, 'some.domain', 'some.domain:'),
                 ],
             ],
             [
@@ -477,10 +489,32 @@ class FullTokenizerTest extends TestCase
                 ],
             ],
             [
+                'some.domain:"phrase"',
+                [
+                    new PhraseToken('some.domain:"phrase"', 0, 'some.domain', '"', 'phrase'),
+                ],
+            ],
+            [
                 'domain\:"phrase"',
                 [
                     new WordToken('domain\:', 0, '', 'domain:'),
                     new PhraseToken('"phrase"', 8, '', '"', 'phrase'),
+                ],
+            ],
+            [
+                'domain:(one)',
+                [
+                    new GroupBeginToken('domain:(', 0, '(', 'domain'),
+                    new WordToken('one', 8, '', 'one'),
+                    new Token(Tokenizer::TOKEN_GROUP_END, ')', 11),
+                ],
+            ],
+            [
+                'some.domain:(one)',
+                [
+                    new GroupBeginToken('some.domain:(', 0, '(', 'some.domain'),
+                    new WordToken('one', 13, '', 'one'),
+                    new Token(Tokenizer::TOKEN_GROUP_END, ')', 16),
                 ],
             ],
             [

--- a/tests/Galach/Tokenizer/TextTokenizerTest.php
+++ b/tests/Galach/Tokenizer/TextTokenizerTest.php
@@ -98,6 +98,9 @@ class TextTokenizerTest extends FullTokenizerTest
             'domain:domain:' => [
                 new WordToken('domain:domain:', 0, '', 'domain:domain:'),
             ],
+            'some.domain:some.domain:' => [
+                new WordToken('some.domain:some.domain:', 0, '', 'some.domain:some.domain:'),
+            ],
             'domain:domain:domain:domain' => [
                 new WordToken('domain:domain:domain:domain', 0, '', 'domain:domain:domain:domain'),
             ],
@@ -116,6 +119,10 @@ class TextTokenizerTest extends FullTokenizerTest
             'domain:"phrase"' => [
                 new WordToken('domain:', 0, '', 'domain:'),
                 new PhraseToken('"phrase"', 7, '', '"', 'phrase'),
+            ],
+            'some.domain:"phrase"' => [
+                new WordToken('some.domain:', 0, '', 'some.domain:'),
+                new PhraseToken('"phrase"', 12, '', '"', 'phrase'),
             ],
             'domain\:"phrase"' => [
                 new WordToken('domain\:', 0, '', 'domain\:'),


### PR DESCRIPTION
This allows domain strings to contain a dot `.`.

Fixes #5.