### PR TITLE
Remove support for group domains in Text extractor

### DIFF
--- a/lib/Languages/Galach/Parser.php
+++ b/lib/Languages/Galach/Parser.php
@@ -10,7 +10,6 @@ use QueryTranslator\Languages\Galach\Values\Node\Mandatory;
 use QueryTranslator\Languages\Galach\Values\Node\Prohibited;
 use QueryTranslator\Languages\Galach\Values\Node\Query;
 use QueryTranslator\Languages\Galach\Values\Node\Term;
-use QueryTranslator\Languages\Galach\Values\Token\GroupBegin;
 use QueryTranslator\Parsing;
 use QueryTranslator\Values\Correction;
 use QueryTranslator\Values\Node;
@@ -288,7 +287,7 @@ final class Parser implements Parsing
         return new Term($token);
     }
 
-    protected function shiftGroupBegin(GroupBegin $token)
+    protected function shiftGroupBegin(Token $token)
     {
         $this->stack->push($token);
     }

--- a/lib/Languages/Galach/README.md
+++ b/lib/Languages/Galach/README.md
@@ -406,6 +406,19 @@ abstract methods to implement when extending the base [TokenExtractor](TokenExtr
     expressions with named capturing groups to extract meaning from the input string and pass it to
     the constructor method.
 
+Optionally you can override the `createGroupBeginToken()` method. This is useful if you want to
+customize token of the `Tokenizer::TOKEN_GROUP_BEGIN` type:
+
+- `createGroupBeginToken($position, array $data): Token`
+
+    Here you receive Token data extracted through regular expression matching and a position where
+    the data was extracted at. From that, you must return the corresponding Token instance of the
+    `Tokenizer::TOKEN_GROUP_BEGIN` type.
+
+    If needed, here you can return an instance of your own Token subtype. You can use regular
+    expressions with named capturing groups to extract meaning from the input string and pass it to
+    the constructor method.
+
 Two TokenExtractor implementations are provided out of the box. You can use them as an example and a
 starting point to implement your own. These are:
 

--- a/lib/Languages/Galach/TokenExtractor.php
+++ b/lib/Languages/Galach/TokenExtractor.php
@@ -82,7 +82,7 @@ abstract class TokenExtractor
     private function createToken($type, $position, array $data)
     {
         if ($type === Tokenizer::TOKEN_GROUP_BEGIN) {
-            return $this->createGroupToken($position, $data);
+            return $this->createGroupBeginToken($position, $data);
         }
 
         if ($type === Tokenizer::TOKEN_TERM) {
@@ -98,9 +98,9 @@ abstract class TokenExtractor
      * @param $position
      * @param array $data
      *
-     * @return \QueryTranslator\Languages\Galach\Values\Token\GroupBegin
+     * @return \QueryTranslator\Values\Token
      */
-    private function createGroupToken($position, array $data)
+    protected function createGroupBeginToken($position, array $data)
     {
         return new GroupBegin($data['lexeme'], $position, $data['delimiter'], $data['domain']);
     }

--- a/lib/Languages/Galach/TokenExtractor.php
+++ b/lib/Languages/Galach/TokenExtractor.php
@@ -52,7 +52,9 @@ abstract class TokenExtractor
      * Return a map of regular expressions to token types.
      *
      * The returned map must be an array where key is a regular expression
-     * and value is a corresponding token type.
+     * and value is a corresponding token type. Regular expression must define
+     * named capturing group 'lexeme' that identifies part of the input string
+     * recognized as token.
      *
      * @return array
      */

--- a/lib/Languages/Galach/TokenExtractor/Text.php
+++ b/lib/Languages/Galach/TokenExtractor/Text.php
@@ -4,6 +4,7 @@ namespace QueryTranslator\Languages\Galach\TokenExtractor;
 
 use QueryTranslator\Languages\Galach\TokenExtractor;
 use QueryTranslator\Languages\Galach\Tokenizer;
+use QueryTranslator\Languages\Galach\Values\Token\GroupBegin;
 use QueryTranslator\Languages\Galach\Values\Token\Phrase;
 use QueryTranslator\Languages\Galach\Values\Token\Word;
 use RuntimeException;
@@ -29,7 +30,7 @@ final class Text extends TokenExtractor
         '/(?<lexeme>NOT)(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_NOT,
         '/(?<lexeme>(?:AND|&&))(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_AND,
         '/(?<lexeme>(?:OR|\|\|))(?:[\s"()+\-!]|$)/Au' => Tokenizer::TOKEN_LOGICAL_OR,
-        '/(?<lexeme>(?:(?<domain>[a-zA-Z_][a-zA-Z0-9_\-.]*):)?(?<delimiter>\())/Au' => Tokenizer::TOKEN_GROUP_BEGIN,
+        '/(?<lexeme>\()/Au' => Tokenizer::TOKEN_GROUP_BEGIN,
         '/(?<lexeme>(?<quote>(?<!\\\\)["])(?<phrase>.*?)(?:(?<!\\\\)(?P=quote)))/Aus' => Tokenizer::TOKEN_TERM,
         '/(?<lexeme>(?<word>(?:\\\\\\\\|\\\\ |\\\\\(|\\\\\)|\\\\"|[^"()\s])+?))(?:(?<!\\\\)["]|\(|\)|$|\s)/Au' => Tokenizer::TOKEN_TERM,
     ];
@@ -66,5 +67,10 @@ final class Text extends TokenExtractor
         }
 
         throw new RuntimeException('Could not extract term token from the given data');
+    }
+
+    protected function createGroupBeginToken($position, array $data)
+    {
+        return new GroupBegin($data['lexeme'], $position, $data['lexeme'], '');
     }
 }

--- a/tests/Galach/Tokenizer/TextTokenizerTest.php
+++ b/tests/Galach/Tokenizer/TextTokenizerTest.php
@@ -128,6 +128,18 @@ class TextTokenizerTest extends FullTokenizerTest
                 new WordToken('domain\:', 0, '', 'domain\:'),
                 new PhraseToken('"phrase"', 8, '', '"', 'phrase'),
             ],
+            'domain:(one)' => [
+                new WordToken('domain:', 0, '', 'domain:'),
+                new GroupBeginToken('(', 7, '(', ''),
+                new WordToken('one', 8, '', 'one'),
+                new Token(Tokenizer::TOKEN_GROUP_END, ')', 11),
+            ],
+            'some.domain:(one)' => [
+                new WordToken('some.domain:', 0, '', 'some.domain:'),
+                new GroupBeginToken('(', 12, '(', ''),
+                new WordToken('one', 13, '', 'one'),
+                new Token(Tokenizer::TOKEN_GROUP_END, ')', 16),
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #6.

Depends on #7, needs rebase after that is merged.

This also exposed the need to customize creation of GroupBegin token, for that reason `TokenExtractor::createGroupBeginToken()` is made protected to allow override. For now implementation is kept for BC reasons, but with v2 this method should become abstract.