### PR TITLE
Update composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         }
     ],
     "require": {
-        "php": "~5.6|~7.0"
+        "php": "^5.6||^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7|^6.0|^7.0"
+        "phpunit/phpunit": "^5.7||^6.0 ||^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Composer uses `||` for OR, not single `|` (it is deprecated)