### PR TITLE
Remove phpunit 5 support

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,13 +1,14 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__)
-    ->exclude([])
-    ->files()->name('*.php')
+    ->exclude('vendor/')
+    ->in('lib')
+    ->in('tests')
 ;
 
 return PhpCsFixer\Config::create()
     ->setRules([
+        '@PHPUnit60Migration:risky' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
         'concat_space' => ['spacing' => 'one'],

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6||^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7||^6.0 ||^7.0",
+        "phpunit/phpunit": "^6.0|^7.0",
         "friendsofphp/php-cs-fixer": "^2.11"
     },
     "autoload": {

--- a/lib/Languages/Galach/Generators/Common/Visitor.php
+++ b/lib/Languages/Galach/Generators/Common/Visitor.php
@@ -27,5 +27,5 @@ abstract class Visitor
      *
      * @return string
      */
-    abstract public function visit(Node $node, Visitor $subVisitor = null, $options = null);
+    abstract public function visit(Node $node, self $subVisitor = null, $options = null);
 }

--- a/lib/Languages/Galach/Generators/Lucene/Common/Group.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/Group.php
@@ -33,7 +33,7 @@ final class Group extends Visitor
      */
     public function __construct(array $domainFieldMap = null, $defaultFieldName = null)
     {
-        if ($domainFieldMap !== null) {
+        if (null !== $domainFieldMap) {
             $this->domainFieldMap = $domainFieldMap;
         }
 
@@ -53,7 +53,7 @@ final class Group extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 
@@ -78,7 +78,7 @@ final class Group extends Visitor
      */
     private function getSolrFieldPrefix(GroupBegin $token)
     {
-        if ($token->domain === '') {
+        if ('' === $token->domain) {
             return '';
         }
 

--- a/lib/Languages/Galach/Generators/Lucene/Common/LogicalAnd.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/LogicalAnd.php
@@ -25,7 +25,7 @@ final class LogicalAnd extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 

--- a/lib/Languages/Galach/Generators/Lucene/Common/LogicalNot.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/LogicalNot.php
@@ -25,7 +25,7 @@ final class LogicalNot extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 

--- a/lib/Languages/Galach/Generators/Lucene/Common/LogicalOr.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/LogicalOr.php
@@ -25,7 +25,7 @@ final class LogicalOr extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 

--- a/lib/Languages/Galach/Generators/Lucene/Common/Mandatory.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/Mandatory.php
@@ -25,7 +25,7 @@ final class Mandatory extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 

--- a/lib/Languages/Galach/Generators/Lucene/Common/Phrase.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/Phrase.php
@@ -33,7 +33,7 @@ final class Phrase extends Visitor
      */
     public function __construct(array $domainFieldMap = null, $defaultFieldName = null)
     {
-        if ($domainFieldMap !== null) {
+        if (null !== $domainFieldMap) {
             $this->domainFieldMap = $domainFieldMap;
         }
 
@@ -76,7 +76,7 @@ final class Phrase extends Visitor
      */
     private function getSolrFieldPrefix(PhraseToken $token)
     {
-        if ($token->domain === '') {
+        if ('' === $token->domain) {
             return '';
         }
 

--- a/lib/Languages/Galach/Generators/Lucene/Common/Prohibited.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/Prohibited.php
@@ -25,7 +25,7 @@ final class Prohibited extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 

--- a/lib/Languages/Galach/Generators/Lucene/Common/Query.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/Query.php
@@ -25,7 +25,7 @@ final class Query extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 

--- a/lib/Languages/Galach/Generators/Lucene/Common/Tag.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/Tag.php
@@ -47,7 +47,7 @@ final class Tag extends Visitor
             );
         }
 
-        $fieldPrefix = $this->fieldName === null ? '' : "{$this->fieldName}:";
+        $fieldPrefix = null === $this->fieldName ? '' : "{$this->fieldName}:";
 
         return "{$fieldPrefix}{$token->tag}";
     }

--- a/lib/Languages/Galach/Generators/Lucene/Common/User.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/User.php
@@ -47,7 +47,7 @@ final class User extends Visitor
             );
         }
 
-        $fieldPrefix = $this->fieldName === null ? '' : "{$this->fieldName}:";
+        $fieldPrefix = null === $this->fieldName ? '' : "{$this->fieldName}:";
 
         return "{$fieldPrefix}{$token->user}";
     }

--- a/lib/Languages/Galach/Generators/Lucene/Common/WordBase.php
+++ b/lib/Languages/Galach/Generators/Lucene/Common/WordBase.php
@@ -33,7 +33,7 @@ abstract class WordBase extends Visitor
      */
     public function __construct(array $domainFieldMap = null, $defaultFieldName = null)
     {
-        if ($domainFieldMap !== null) {
+        if (null !== $domainFieldMap) {
             $this->domainFieldMap = $domainFieldMap;
         }
 
@@ -85,7 +85,7 @@ abstract class WordBase extends Visitor
      */
     private function getSolrFieldPrefix(WordToken $token)
     {
-        if ($token->domain === '') {
+        if ('' === $token->domain) {
             return '';
         }
 

--- a/lib/Languages/Galach/Generators/Native/BinaryOperator.php
+++ b/lib/Languages/Galach/Generators/Native/BinaryOperator.php
@@ -26,7 +26,7 @@ final class BinaryOperator extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 

--- a/lib/Languages/Galach/Generators/Native/Group.php
+++ b/lib/Languages/Galach/Generators/Native/Group.php
@@ -25,7 +25,7 @@ final class Group extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 
@@ -36,7 +36,7 @@ final class Group extends Visitor
         }
 
         $clauses = implode(' ', $clauses);
-        $domainPrefix = $node->tokenLeft->domain === '' ? '' : "{$node->tokenLeft->domain}:";
+        $domainPrefix = '' === $node->tokenLeft->domain ? '' : "{$node->tokenLeft->domain}:";
 
         return "{$domainPrefix}{$node->tokenLeft->delimiter}{$clauses}{$node->tokenRight->lexeme}";
     }

--- a/lib/Languages/Galach/Generators/Native/Phrase.php
+++ b/lib/Languages/Galach/Generators/Native/Phrase.php
@@ -34,7 +34,7 @@ final class Phrase extends Visitor
             );
         }
 
-        $domainPrefix = $token->domain === '' ? '' : "{$token->domain}:";
+        $domainPrefix = '' === $token->domain ? '' : "{$token->domain}:";
         $phraseEscaped = preg_replace("/([\\{$token->quote}])/", '\\\\$1', $token->phrase);
 
         return "{$domainPrefix}{$token->quote}{$phraseEscaped}{$token->quote}";

--- a/lib/Languages/Galach/Generators/Native/Query.php
+++ b/lib/Languages/Galach/Generators/Native/Query.php
@@ -25,7 +25,7 @@ final class Query extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 

--- a/lib/Languages/Galach/Generators/Native/UnaryOperator.php
+++ b/lib/Languages/Galach/Generators/Native/UnaryOperator.php
@@ -28,14 +28,14 @@ final class UnaryOperator extends Visitor
             );
         }
 
-        if ($subVisitor === null) {
+        if (null === $subVisitor) {
             throw new LogicException('Implementation requires sub-visitor');
         }
 
         $clause = $subVisitor->visit($node->operand, $subVisitor, $options);
 
         $padding = '';
-        if ($node->token->type === Tokenizer::TOKEN_LOGICAL_NOT) {
+        if (Tokenizer::TOKEN_LOGICAL_NOT === $node->token->type) {
             $padding = ' ';
         }
 

--- a/lib/Languages/Galach/Generators/Native/Word.php
+++ b/lib/Languages/Galach/Generators/Native/Word.php
@@ -34,7 +34,7 @@ final class Word extends Visitor
             );
         }
 
-        $domainPrefix = $token->domain === '' ? '' : "{$token->domain}:";
+        $domainPrefix = '' === $token->domain ? '' : "{$token->domain}:";
         $wordEscaped = preg_replace('/([\\\'"+\-!():#@ ])/', '\\\\$1', $token->word);
 
         return "{$domainPrefix}{$wordEscaped}";

--- a/lib/Languages/Galach/TokenExtractor.php
+++ b/lib/Languages/Galach/TokenExtractor.php
@@ -73,28 +73,6 @@ abstract class TokenExtractor
     abstract protected function createTermToken($position, array $data);
 
     /**
-     * Create a token object from the given parameters.
-     *
-     * @param int $type Token type
-     * @param int $position Position of the token in the input string
-     * @param array $data Regex match data, depends on the type of the token
-     *
-     * @return \QueryTranslator\Values\Token
-     */
-    private function createToken($type, $position, array $data)
-    {
-        if ($type === Tokenizer::TOKEN_GROUP_BEGIN) {
-            return $this->createGroupBeginToken($position, $data);
-        }
-
-        if ($type === Tokenizer::TOKEN_TERM) {
-            return $this->createTermToken($position, $data);
-        }
-
-        return new Token($type, $data['lexeme'], $position);
-    }
-
-    /**
      * Create an instance of Group token by the given parameters.
      *
      * @param $position
@@ -105,6 +83,28 @@ abstract class TokenExtractor
     protected function createGroupBeginToken($position, array $data)
     {
         return new GroupBegin($data['lexeme'], $position, $data['delimiter'], $data['domain']);
+    }
+
+    /**
+     * Create a token object from the given parameters.
+     *
+     * @param int $type Token type
+     * @param int $position Position of the token in the input string
+     * @param array $data Regex match data, depends on the type of the token
+     *
+     * @return \QueryTranslator\Values\Token
+     */
+    private function createToken($type, $position, array $data)
+    {
+        if (Tokenizer::TOKEN_GROUP_BEGIN === $type) {
+            return $this->createGroupBeginToken($position, $data);
+        }
+
+        if (Tokenizer::TOKEN_TERM === $type) {
+            return $this->createTermToken($position, $data);
+        }
+
+        return new Token($type, $data['lexeme'], $position);
     }
 
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php"
-         colors="true"
+<phpunit colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          syntaxCheck="true">
     <testsuites>
         <testsuite name="Query parser tests">
-            <directory suffix="Test.php">./tests</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/tests/Galach/Generators/AggregateVisitorDispatchTest.php
+++ b/tests/Galach/Generators/AggregateVisitorDispatchTest.php
@@ -19,12 +19,11 @@ class AggregateVisitorDispatchTest extends TestCase
         $this->assertTrue((new Aggregate())->accept($nodeMock));
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage No visitor available for Mock
-     */
     public function testVisitThrowsException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('No visitor available for Mock');
+
         /** @var \QueryTranslator\Values\Node $nodeMock */
         $nodeMock = $this->getMockBuilder(Node::class)->getMock();
 

--- a/tests/Galach/Generators/LuceneVisitorDispatchTest.php
+++ b/tests/Galach/Generators/LuceneVisitorDispatchTest.php
@@ -104,7 +104,6 @@ class LuceneVisitorDispatchTest extends TestCase
     /**
      * @dataProvider providerForTestVisitThrowsLogicExceptionNode
      *
-     * @expectedException \LogicException
      *
      * @param \QueryTranslator\Languages\Galach\Generators\Common\Visitor $visitor
      * @param \QueryTranslator\Values\Node $node
@@ -112,6 +111,8 @@ class LuceneVisitorDispatchTest extends TestCase
      */
     public function testVisitThrowsLogicExceptionNode(Visitor $visitor, Node $node, $expectedExceptionMessage)
     {
+        $this->expectException(\LogicException::class);
+
         try {
             $visitor->visit($node);
         } catch (LogicException $e) {
@@ -158,7 +159,6 @@ class LuceneVisitorDispatchTest extends TestCase
     /**
      * @dataProvider providerForTestVisitThrowsLogicExceptionToken
      *
-     * @expectedException \LogicException
      *
      * @param \QueryTranslator\Languages\Galach\Generators\Common\Visitor $visitor
      * @param \QueryTranslator\Values\Node $node
@@ -166,6 +166,8 @@ class LuceneVisitorDispatchTest extends TestCase
      */
     public function testVisitThrowsLogicExceptionToken(Visitor $visitor, Node $node, $expectedExceptionMessage)
     {
+        $this->expectException(\LogicException::class);
+
         try {
             $visitor->visit($node);
         } catch (LogicException $e) {
@@ -211,14 +213,15 @@ class LuceneVisitorDispatchTest extends TestCase
     /**
      * @dataProvider providerForTestVisitThrowsLogicExceptionSubVisitor
      *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Implementation requires sub-visitor
      *
      * @param \QueryTranslator\Languages\Galach\Generators\Common\Visitor $visitor
      * @param \QueryTranslator\Values\Node $node
      */
     public function testVisitThrowsLogicExceptionSubVisitor(Visitor $visitor, Node $node)
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Implementation requires sub-visitor');
+
         $visitor->visit($node);
     }
 }

--- a/tests/Galach/Generators/NativeVisitorDispatchTest.php
+++ b/tests/Galach/Generators/NativeVisitorDispatchTest.php
@@ -80,7 +80,6 @@ class NativeVisitorDispatchTest extends TestCase
     /**
      * @dataProvider providerForTestVisitThrowsLogicExceptionNode
      *
-     * @expectedException \LogicException
      *
      * @param \QueryTranslator\Languages\Galach\Generators\Common\Visitor $visitor
      * @param \QueryTranslator\Values\Node $node
@@ -88,6 +87,8 @@ class NativeVisitorDispatchTest extends TestCase
      */
     public function testVisitThrowsLogicExceptionNode(Visitor $visitor, Node $node, $expectedExceptionMessage)
     {
+        $this->expectException(\LogicException::class);
+
         try {
             $visitor->visit($node);
         } catch (LogicException $e) {
@@ -129,7 +130,6 @@ class NativeVisitorDispatchTest extends TestCase
     /**
      * @dataProvider providerForTestVisitThrowsLogicExceptionToken
      *
-     * @expectedException \LogicException
      *
      * @param \QueryTranslator\Languages\Galach\Generators\Common\Visitor $visitor
      * @param \QueryTranslator\Values\Node $node
@@ -137,6 +137,8 @@ class NativeVisitorDispatchTest extends TestCase
      */
     public function testVisitThrowsLogicExceptionToken(Visitor $visitor, Node $node, $expectedExceptionMessage)
     {
+        $this->expectException(\LogicException::class);
+
         try {
             $visitor->visit($node);
         } catch (LogicException $e) {
@@ -182,14 +184,15 @@ class NativeVisitorDispatchTest extends TestCase
     /**
      * @dataProvider providerForTestVisitThrowsLogicExceptionSubVisitor
      *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Implementation requires sub-visitor
      *
      * @param \QueryTranslator\Languages\Galach\Generators\Common\Visitor $visitor
      * @param \QueryTranslator\Values\Node $node
      */
     public function testVisitThrowsLogicExceptionSubVisitor(Visitor $visitor, Node $node)
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Implementation requires sub-visitor');
+
         $visitor->visit($node);
     }
 }

--- a/tests/Galach/IntegrationTest.php
+++ b/tests/Galach/IntegrationTest.php
@@ -3459,7 +3459,7 @@ class IntegrationTest extends TestCase
 
         $tokensWithoutWhitespace = [];
         foreach ($tokenSequence->tokens as $token) {
-            if ($token->type !== Tokenizer::TOKEN_WHITESPACE) {
+            if (Tokenizer::TOKEN_WHITESPACE !== $token->type) {
                 $tokensWithoutWhitespace[] = $token;
             }
         }

--- a/tests/Galach/Tokenizer/FullTokenizerTest.php
+++ b/tests/Galach/Tokenizer/FullTokenizerTest.php
@@ -5,8 +5,8 @@ namespace QueryTranslator\Tests\Galach\Tokenizer;
 use PHPUnit\Framework\TestCase;
 use QueryTranslator\Languages\Galach\TokenExtractor;
 use QueryTranslator\Languages\Galach\Tokenizer;
-use QueryTranslator\Languages\Galach\Values\Token\GroupBegin as GroupBeginToken;
 use QueryTranslator\Languages\Galach\Values\Token\GroupBegin;
+use QueryTranslator\Languages\Galach\Values\Token\GroupBegin as GroupBeginToken;
 use QueryTranslator\Languages\Galach\Values\Token\Phrase as PhraseToken;
 use QueryTranslator\Languages\Galach\Values\Token\Tag as TagToken;
 use QueryTranslator\Languages\Galach\Values\Token\User as UserToken;
@@ -245,23 +245,23 @@ class FullTokenizerTest extends TestCase
                 [
                     new WordToken("'word", 0, '', "'word"),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 5),
-                    new WordToken("\\+", 6, '', '+'),
+                    new WordToken('\\+', 6, '', '+'),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 8),
-                    new WordToken("\\-", 9, '', '-'),
+                    new WordToken('\\-', 9, '', '-'),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 11),
-                    new WordToken("\\!", 12, '', '!'),
+                    new WordToken('\\!', 12, '', '!'),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 14),
-                    new WordToken("\\(", 15, '', '('),
+                    new WordToken('\\(', 15, '', '('),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 17),
-                    new WordToken("\\)", 18, '', ')'),
+                    new WordToken('\\)', 18, '', ')'),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 20),
-                    new WordToken("\\AND", 21, '', '\AND'),
+                    new WordToken('\\AND', 21, '', '\AND'),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 25),
-                    new WordToken("\\OR", 26, '', '\OR'),
+                    new WordToken('\\OR', 26, '', '\OR'),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 29),
-                    new WordToken("\\NOT", 30, '', '\NOT'),
+                    new WordToken('\\NOT', 30, '', '\NOT'),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 34),
-                    new WordToken("\\\\", 35, '', '\\'),
+                    new WordToken('\\\\', 35, '', '\\'),
                     new Token(Tokenizer::TOKEN_WHITESPACE, ' ', 37),
                     new WordToken("word'", 38, '', "word'"),
                 ],

--- a/tests/Galach/Tokenizer/TokenExtractorTest.php
+++ b/tests/Galach/Tokenizer/TokenExtractorTest.php
@@ -13,12 +13,11 @@ use QueryTranslator\Languages\Galach\Tokenizer;
  */
 class TokenExtractorTest extends TestCase
 {
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage PCRE regex error code: 2
-     */
     public function testExtractThrowsExceptionPCRE()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('PCRE regex error code: 2');
+
         /** @var \QueryTranslator\Languages\Galach\TokenExtractor|\PHPUnit_Framework_MockObject_MockObject $extractor */
         $extractor = $this->getMockBuilder(TokenExtractor::class)
             ->setMethods(['getExpressionTypeMap'])
@@ -35,12 +34,11 @@ class TokenExtractorTest extends TestCase
         $extractor->extract('foobar foobar foobar', 0);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Could not extract term token from the given data
-     */
     public function testFullExtractTermTokenThrowsException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not extract term token from the given data');
+
         $extractor = new Full();
         $reflectedClass = new \ReflectionClass($extractor);
         $reflectedProperty = $reflectedClass->getProperty('expressionTypeMap');
@@ -54,12 +52,11 @@ class TokenExtractorTest extends TestCase
         $extractor->extract('foobar', 0);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Could not extract term token from the given data
-     */
     public function testTextExtractTermTokenThrowsException()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Could not extract term token from the given data');
+
         $extractor = new Text();
         $reflectedClass = new \ReflectionClass($extractor);
         $reflectedProperty = $reflectedClass->getProperty('expressionTypeMap');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,8 +1,0 @@
-<?php
-
-$autoload = __DIR__ . '/../vendor/autoload.php';
-if (!file_exists($autoload)) {
-    throw new RuntimeException('Install dependencies using composer to run the test suite.');
-}
-
-require_once $autoload;


### PR DESCRIPTION
PHPunit 5.x is deprecated since february 2018.

- [x] Removed phpunit 5.x support
- [x] Applied php-cs-fixer CS fixes (including migration to phpunit => 6.x)